### PR TITLE
🔧 Fix:  new MIUI is forcing apps to be dark

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
When system dark mode is set, MIUI forces apps to be dark by inverting colors which cause the dog to be black.
This line fixes the issue.